### PR TITLE
Fixes a potential problem with experiment dir being specified with ~

### DIFF
--- a/spearmint/main.py
+++ b/spearmint/main.py
@@ -213,7 +213,7 @@ def get_options():
     (commandline_kwargs, args) = parser.parse_args()
 
     # Read in the config file
-    expt_dir  = os.path.realpath(args[0])
+    expt_dir  = os.path.realpath(os.path.expanduser(args[0]))
     if not os.path.isdir(expt_dir):
         raise Exception("Cannot find directory %s" % expt_dir)
     expt_file = os.path.join(expt_dir, commandline_kwargs.config_file)


### PR DESCRIPTION
As per #8 , this fixes a potential problem where the path to the experiment dir begins with the ~ character.
