### PR TITLE
[WIP] fixed print for enum fixes #15

### DIFF
--- a/spearmint/tasks/base_task.py
+++ b/spearmint/tasks/base_task.py
@@ -254,6 +254,8 @@ class BaseTask(object):
 
             if param['type'] == 'float':
                 format_str = '%s%-12.12s  %-9.9s  %-12f\n'
+            elif param['type'] == 'enum':
+                format_str = '%s%-12.12s  %-9.9s  %-12s\n'
             else:
                 format_str = '%s%-12.12s  %-9.9s  %-12d\n'
 


### PR DESCRIPTION
Previously, when the enum options were strings, they would not print.

This fixes that case. I'm not sure if enums can be floats/ints, but this would probably break that case. I'll check and update the PR if necessary.

I agree to the contributors license agreement.