### PR TITLE
Make options and expt_dir args to main.main

### DIFF
--- a/spearmint/main.py
+++ b/spearmint/main.py
@@ -225,6 +225,9 @@ def get_options():
         raise Exception("config.json did not load properly. Perhaps a spurious comma?")
     options["config"]  = commandline_kwargs.config_file
 
+    return options, expt_dir
+
+def main(options, expt_dir):
 
     # Set sensible defaults for options
     options['chooser']  = options.get('chooser', 'default_chooser')
@@ -242,11 +245,6 @@ def get_options():
         sys.stderr.write("Cannot find experiment directory '%s'. "
                          "Aborting.\n" % (expt_dir))
         sys.exit(-1)
-
-    return options, expt_dir
-
-def main():
-    options, expt_dir = get_options()
 
     resources = parse_resources_from_config(options)
 
@@ -491,4 +489,4 @@ def print_diagnostics(chooser):
     best_job_fh.close()
 
 if __name__ == '__main__':
-    main()
+    main(*get_options())


### PR DESCRIPTION
Hi, I'd like to propose that instead of calling `get_options` in `main.main` to retrieve `options` and `expt_dir`, they are instead passed as arguments to `main.main`.  As it currently is, the only way to run a Spearmint experiment is to run `python main.py`.  With this change, that option is still available, but it will also be possible to run `main.main` from within a Python script - something like the following:

```Python
import spearmint.main
import os
import numpy as np

def branin(x, y):
    result = np.square(y - (5.1/(4*np.square(np.pi)))*np.square(x) +
         (5/np.pi)*x - 6) + 10*(1-(1./(8*np.pi)))*np.cos(x) + 10
    result = float(result)
    print 'Result = %f' % result
    return result

def main(job_id, params):
    return branin(params['x'], params['y'])

options = {'language' : 'PYTHON',
           'main-file' : os.path.basename(__file__),
           'experiment-name' : 'noconfig',
           'likelihood' : 'NOISELESS',
           'variables' : {"x" : {"type" : "FLOAT",
                                 "size" : 1,
                                 "min"  : -5,
                                 "max"  : 10},
                          "y" : {"type" : "FLOAT",
                                 "size" : 1,
                                 "min"  : 0,
                                 "max"  : 15}}}

if __name__ == '__main__':
    spearmint.main.main(options, os.getcwd())
```

Note that this consolidates the main.py file and the experiment file, makes the 'main-file' option resilient to filename changes, and also obviates the need for a config file - we can just turn the config into a dict in the experiment file.  And, again, it doesn't change the existing behavior.  If there's something fundamental I'm missing here which suggests this is a bad idea, please correct me, but otherwise I think this small change would substantially clean up many use-cases!  Thanks.