### PR TITLE
Add entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,4 @@
 *.DS_Store
 *.pdf
 *.py~
-
-
-
+*.egg-info

--- a/setup.py
+++ b/setup.py
@@ -28,4 +28,5 @@ setup(
               'spearmint.utils',
               'spearmint.utils.database',],
     long_description=read('README.md'),
+    entry_points= {'console_scripts': ['spearmint=spearmint.main:main']},
 )


### PR DESCRIPTION
This PR:

- [x] Adds a new entry point. This way, installing Spearmint creates a new executable file called ```spearmint```. To execute the experiments, you can issue ```spearmint --config config.json path/to/experiment``` wherever you want to get the outputs in your system.
- [x] Added entry in ```.gitignore``` so that ```python setup.py develop``` can be used to deploy spearmint in development environments.