### PR TITLE
Fixed problem with experiments with 1 variable

### DIFF
--- a/spearmint/tasks/base_task.py
+++ b/spearmint/tasks/base_task.py
@@ -243,7 +243,7 @@ class BaseTask(object):
     def paramify_and_print(self, data_vector, left_indent=0, indent_top_row=False):
         params = self.paramify(data_vector)
         indentation = ' '*left_indent
-        
+
         if indent_top_row:
             sys.stderr.write(indentation)
         sys.stderr.write('NAME          TYPE       VALUE\n')
@@ -263,7 +263,7 @@ class BaseTask(object):
                 if i == 0:
                     sys.stderr.write(format_str % (indentation, param_name, param['type'], param['values'][i]))
                 else:
-                    sys.stderr.write(format_str % (indentation, '',                        param['values'][i]))
+                    sys.stderr.write(format_str % (indentation, '', '',                    param['values'][i]))
 
     # Converts a vector in input space to the corresponding dict of params
     def paramify(self, data_vector):
@@ -284,7 +284,7 @@ class BaseTask(object):
                     params[name]['values'].append(vdict['options'][data_vector[ind].argmax(0)])
             else:
                 raise Exception('Unknown parameter type.')
-            
+
         return params
 
     # Converts a dict of params to the corresponding vector in puts space
@@ -334,7 +334,7 @@ class BaseTask(object):
             U = np.squeeze(U)
 
         return U
-        
+
     def from_unit(self, U):
         if U.shape[0] == 0:
             return np.array([])
@@ -368,14 +368,14 @@ class BaseTask(object):
                 raise Exception("Unknown variable type: %s" % variable['type'])
 
         if squeeze:
-            V = np.squeeze(V)
+            V = np.ma.atleast_1d(np.squeeze(V))
 
         return V
 
     # Convert primitive types to the unit hypercube
     def int_to_unit(self, v, vmin, vmax):
         unit = (np.double(v) - vmin) / (vmax - vmin)
-        
+
         # Make sure we are not over bounds
         try:
             unit[unit > 1] = 1
@@ -389,7 +389,7 @@ class BaseTask(object):
 
     def float_to_unit(self, v, vmin, vmax):
         unit = (np.double(v) - vmin) / (vmax - vmin)
-        
+
         # Make sure we are not over bounds
         try:
             unit[unit > 1] = 1.0


### PR DESCRIPTION
Hi,

I ran into a problem when trying to run experiments optimizing just one variable/parameter. Apparently the np.squeeze() function was not producing an array of the expected size in this case.

This tiny commit fixes the problem.