### PR TITLE
added format_str for enum type

### DIFF
--- a/spearmint/tasks/input_space.py
+++ b/spearmint/tasks/input_space.py
@@ -282,8 +282,10 @@ class InputSpace(object):
 
             if param['type'] == 'float':
                 format_str = '%s%-12.12s  %-9.9s  %-12f'
-            else:
+            elif param['type'] == 'int':
                 format_str = '%s%-12.12s  %-9.9s  %-12d'
+            else:
+                format_str = '%s%-12.12s  %-9.9s  %-12s'
 
             for i in xrange(len(param['values'])):
                 if i == 0:


### PR DESCRIPTION
Format string was missing and so spearmint would return error when using enum type of variables with strings